### PR TITLE
make the logo icon smaller and make it sticky on scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,7 +7,7 @@
 }
 
 .wobble {
-  height: 30vmin;
+  height: 10vmin;
   margin: 20px 0 10px 0;
   animation: wobble 2s ease infinite;
 }
@@ -27,6 +27,8 @@
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
+  position: sticky;
+  top: 5px;
 }
 
 .App-link {


### PR DESCRIPTION
I made the icon logo `smaller` and made it `sticky` when the user scrolls down.

Below are videos how the logo will look on `Desktop`, `Tablet` and `Mobile` view:

`Desktop` : 

https://user-images.githubusercontent.com/94648837/203150927-0b6703fb-1d25-4b3c-bcdb-7fb09924bfb3.mov

`Tablet` : 


https://user-images.githubusercontent.com/94648837/203150948-8d7b3177-e39e-4bf6-aff5-79f3a864ae22.mov

`Mobile` : 

https://user-images.githubusercontent.com/94648837/203150982-c33c531d-252b-4634-a85e-2310f134c20a.mov


